### PR TITLE
chore: upgrade Android SDK to 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 0.1.4 - 2024-10-14
+
+- chore: upgrade Android SDK to 3.8.2
+
 ## 0.1.3 - 2024-10-11
 
 - chore: upgrade Android SDK to 3.8.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.8.1"
+  implementation "com.posthog:posthog-android:3.8.2"
 }
 


### PR DESCRIPTION
depends on https://github.com/PostHog/posthog-ios/blob/main/CHANGELOG.md#next
and https://github.com/PostHog/posthog-android/releases/tag/3.8.2