### PR TITLE
chore/target ios 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: target min iOS 13 in podspec
+
 ## 0.1.4 - 2024-10-14
 
 - chore: upgrade Android SDK to 3.8.2

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -14,10 +14,13 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/PostHog/posthog-react-native-session-replay.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
   # ~> Version 3.0 and the versions up to 4.0, not including 4.0 and higher
   s.dependency 'PostHog', '~> 3.0'
+  s.ios.deployment_target = '13.0'
+  s.swift_versions = "5.3"
+
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Relates to https://github.com/PostHog/posthog-js-lite/issues/289
iOS SDK already targets iOS 13, being explicit in this podspec as well