### PR TITLE
chore: pin the iOS SDK to 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 0.1.9 - 2025-01-09
+
+- chore: pin the iOS SDK to 3.18.0
+
 ## 0.1.8 - 2024-11-26
 
 - fix: mask sandboxed system views like photo picker and user library photos

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
   # ~> Version 3.0 and the versions up to 4.0, not including 4.0 and higher
-  s.dependency 'PostHog', '~> 3.0'
+  # Pinned to 3.18.0 until https://posthog.com/questions/pods-suddenly-not-able-to-be-installed is resolved
+  s.dependency 'PostHog', '3.18.0'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 


### PR DESCRIPTION
https://posthog.com/questions/pods-suddenly-not-able-to-be-installed
Closes https://github.com/PostHog/posthog-js-lite/issues/334