### PR TITLE
chore: bump Android SDK to 3.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 1.0.3 - 2025-02-26
+
+- chore: bump Android SDK to 3.11.3
+
 ## 1.0.2 - 2025-02-25
 
 - fix: distinctId and anonymousId should degrade gracefully if they are strings that can't be parsed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.9.2"
+  implementation "com.posthog:posthog-android:3.11.3"
 }
 


### PR DESCRIPTION
Check if it helps with https://github.com/PostHog/posthog-js-lite/issues/406