### PR TITLE
chore: pin the iOS SDK to 3.20.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 1.0.5 - 2025-03-04
+
+- chore: pin the iOS SDK to 3.20.x
+
 ## 1.0.4 - 2025-03-03
 
 - chore: pin the iOS SDK to 3.18.x until we fix [this issue](https://github.com/PostHog/posthog-ios/issues/292)

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,9 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.18.0 up to, but not including, 3.19
-  # fix after https://github.com/PostHog/posthog-ios/issues/292
-  s.dependency 'PostHog', '~> 3.18'
+  # ~> Version 3.20.0 up to, but not including, 3.21
+  s.dependency 'PostHog', '~> 3.20'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.20.0 up to, but not including, 3.21
+  # ~> Version 3.20.0 up to, but not including, 4.0.0
   s.dependency 'PostHog', '~> 3.20'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"


### PR DESCRIPTION
we think https://posthog.com/questions/broken-on-m1-pro-mac-after-version-1-0-0 is a caching issue so lets bump to 3.20 at least, so if someone is on < 3.19.7 where things were fixed, this should not be an issue anymore