### PR TITLE
chore: add types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 1.0.6 - 2025-04-22
+
+- fix: add types key to package.json
+
 ## 1.0.5 - 2025-03-04
 
 - chore: pin the iOS SDK to 3.20.x

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "posthog-react-native-session-replay",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Session Replay",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
+  "types": "./lib/typescript/module/src/index.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
The `types` included inside the `exports` key do not work for all configurations so I'm also adding them at the root level. Type files are the same for commonJS and ESM so just including the one in the `module` directory