### PR TITLE
chore: update posthog-android dependency to 3.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## Next
 
+## 1.1.3 - 2025-08-25
+
+- chore: update posthog-android dependency to 3.20.4
+
 ## 1.1.2 - 2025-08-11
 
-- chore: update posthog-android dependency
+- chore: update posthog-android dependency to 3.20.2
 
 ## 1.1.1 - 2025-06-24
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.20.2"
+  implementation "com.posthog:posthog-android:3.20.4"
 }
 


### PR DESCRIPTION
Fix for https://github.com/PostHog/posthog-js/issues/2233