### PR TITLE
chore: update posthog-android dependency to 3.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 1.1.4 - 2025-09-11
+
+- chore: update posthog-android dependency to 3.21.2
+
 ## 1.1.3 - 2025-08-25
 
 - chore: update posthog-android dependency to 3.20.4

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.20.4"
+  implementation "com.posthog:posthog-android:3.21.2"
 }
 


### PR DESCRIPTION
depends on https://github.com/PostHog/posthog-android/releases/tag/3.21.2
Closes https://github.com/PostHog/posthog-js/issues/2298