### PR TITLE
chore: update posthog-android dependency to 3.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 1.1.5 - 2025-09-16
+
+- chore: update posthog-android dependency to 3.21.3
+
 ## 1.1.4 - 2025-09-11
 
 - chore: update posthog-android dependency to 3.21.2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.21.2"
+  implementation "com.posthog:posthog-android:3.21.3"
 }
 


### PR DESCRIPTION
Bring https://github.com/PostHog/posthog-android/releases/tag/3.21.3 in