### PR TITLE
chore: add GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: 🐞 Bug Report
+description: Tell us about something that's not working the way we (probably) intend.
+labels: ["bug"]
+body:
+
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: SDK Version
+      placeholder: 3.0.0 ← should look like this
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. foo
+        2. bar
+        3. baz
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots? Yes, please.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask in the forums
+    url: https://posthog.com/questions
+    about: A place to ask questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: 💡 Feature Request
+description: Tell us about a problem our SDK could solve but doesn't.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem could we solve that it doesn't?
+      placeholder: |-
+        I want to make whirled peas, but it doesn't blend.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Solution Brainstorm
+      description: We know you have bright ideas to share ... share away, friend.
+      placeholder: |-
+        Add a blender to it.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,0 +1,10 @@
+name: Blank Issue
+description: Blank Issue. Reserved for maintainers.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the issue.
+    validations:
+      required: true


### PR DESCRIPTION
## Problem

Some of the standard GitHub community health files were missing, which made this repo inconsistent with the other client library repositories.

## Changes

- added the shared issue templates under `.github/ISSUE_TEMPLATE`
- kept the existing PR template and CODEOWNERS setup unchanged
- aligned the repo with the standard client libraries contribution metadata

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
