### PR TITLE
docs: remove stale release section from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,16 +81,6 @@ We use [TypeScript](https://www.typescriptlang.org/) for type checking, [ESLint]
 
 Our pre-commit hooks verify that the linter and tests pass when committing.
 
-### Publishing to npm
-
-We use [release-it](https://github.com/release-it/release-it) to make it easier to publish new versions. It handles common tasks like bumping version based on semver, creating tags and releases etc.
-
-To publish new versions, run the following:
-
-```sh
-pnpm release
-```
-
 ### Scripts
 
 The `package.json` file contains various scripts for common tasks:


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` still describes an old manual release flow using `release-it` and `pnpm release`, while `RELEASING.md` already documents the current Changesets + GitHub Actions process. Keeping both creates conflicting guidance for contributors.

## Changes

- removed the outdated "Publishing to npm" section from `CONTRIBUTING.md`
- left `RELEASING.md` as the single source of truth for release instructions

## Checklist

- [ ] Tests for new code (if applicable)
- [ ] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
