### PR TITLE
chore: bump posthog-ios dependency to 3.53.1

### DIFF
--- a/.changeset/salty-bugs-say.md
+++ b/.changeset/salty-bugs-say.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native-session-replay': patch
+---
+
+chore: bump posthog-ios dependency to 3.48.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Print Xcode version
+        run: xcodebuild -version
+
       - name: Setup
         uses: ./.github/actions/setup
 

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.21.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.42.0'
+  # ~> Version 3.48.2 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.48.2'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
   # ~> Version 3.48.2 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.48.2'
+  s.dependency 'PostHog', '~> 3.48.2'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.48.2 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.48.2'
+  # ~> Version 3.53.1 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '~> 3.53.1'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Requires: https://github.com/PostHog/posthog-ios/pull/564

RN: https://github.com/PostHog/posthog-js/pull/3402

Context: https://github.com/PostHog/posthog-ios/issues/553#issuecomment-4256427263

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Checklist

- [ ] Tests for new code (if applicable)
- [ ] Accounted for the impact of any changes across iOS and Android platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
