### PR TITLE
chore: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,9 @@ jobs:
 
       - name: Get GitHub App token
         id: releaser
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_POSTHOG_REACT_NATIVE_SESSION_REPLAY_RELEASER_APP_ID }}
+          client-id: ${{ secrets.GH_APP_POSTHOG_REACT_NATIVE_SESSION_REPLAY_RELEASER_APP_ID }}
           private-key: ${{ secrets.GH_APP_POSTHOG_REACT_NATIVE_SESSION_REPLAY_RELEASER_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Problem
GitHub Actions now warns that `app-id` is deprecated in `actions/create-github-app-token`.
The release workflow should use `client-id`, and older action references should be moved to v3.

## Changes
- switched the release workflow to `client-id`
- upgraded `actions/create-github-app-token` to v3 in the release workflow

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
