### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,25 +11,13 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
         cache: 'pnpm'
-
-    - name: Cache dependencies
-      id: pnpm-cache
-      uses: actions/cache@v5
-      with:
-        path: |
-          **/node_modules
-          .pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/package.json', '!node_modules/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          ${{ runner.os }}-pnpm-
 
     - name: Install dependencies
       if: inputs.install == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup pnpm
         if: ${{ matrix.language == 'swift' || matrix.language == 'java-kotlin' }}
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
         if: ${{ matrix.language == 'swift' || matrix.language == 'java-kotlin' }}


### PR DESCRIPTION
## Problem

Some workflows still use the older pnpm action, and the shared setup action also has a redundant dependency cache that can fail during restore with `/usr/bin/tar` exit code 2.

## Changes

- bumped `pnpm/action-setup` to v5 in the shared setup action and CodeQL workflow
- removed the extra dependency cache from the shared setup action and rely on `actions/setup-node`'s pnpm cache instead

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
