### PR TITLE
chore(ci): trigger release workflow from pushes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.changeset/**'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -15,15 +16,77 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-release-context:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-release: ${{ steps.resolve.outputs.should-release }}
+      bump-type: ${{ steps.resolve.outputs.bump-type }}
+    steps:
+      - name: Resolve release request
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          CURRENT_REF: ${{ github.ref }}
+          DEFAULT_BRANCH: main
+          PUSH_SHA: ${{ github.sha }}
+          PUSH_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          SHOULD_RELEASE=false
+          BUMP_TYPE=""
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$CURRENT_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+              echo "::notice::Skipping release because workflow_dispatch must be run on $DEFAULT_BRANCH, got $CURRENT_REF."
+            else
+              SHOULD_RELEASE=true
+              echo "✓ Manual release requested on $DEFAULT_BRANCH"
+            fi
+
+            echo "should-release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+            echo "bump-type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${PUSH_HEAD_COMMIT_MESSAGE:-}" == *"[version bump]"* || "${PUSH_HEAD_COMMIT_MESSAGE:-}" == "Bump version to "* || "${PUSH_HEAD_COMMIT_MESSAGE:-}" == "chore: Release v"* || "${PUSH_HEAD_COMMIT_MESSAGE:-}" == "chore: release "* ]]; then
+            echo "::notice::Skipping release for the automated version bump commit."
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "bump-type=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PRS_JSON=$(gh api "repos/${{ github.repository }}/commits/$PUSH_SHA/pulls")
+          MATCHING_PR_COUNT=$(echo "$PRS_JSON" | jq --arg branch "$DEFAULT_BRANCH" '[.[] | select(.merged_at != null and .base.ref == $branch and (.labels | map(.name) | index("release")))] | length')
+
+          if [ "$MATCHING_PR_COUNT" -eq 0 ]; then
+            ASSOCIATED_PRS=$(echo "$PRS_JSON" | jq -r '[.[].number | tostring] | join(", ")')
+            if [ -n "$ASSOCIATED_PRS" ]; then
+              echo "::notice::Skipping release because push $PUSH_SHA is associated with PR(s) [$ASSOCIATED_PRS], but none currently have the release label."
+            else
+              echo "::notice::Skipping release because push $PUSH_SHA is not associated with a merged PR to $DEFAULT_BRANCH that has the release label."
+            fi
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "bump-type=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RELEASE_PRS=$(echo "$PRS_JSON" | jq -r --arg branch "$DEFAULT_BRANCH" '[.[] | select(.merged_at != null and .base.ref == $branch and (.labels | map(.name) | index("release"))) | "#\(.number)"] | join(", ")')
+          echo "✓ Release requested by push $PUSH_SHA via $RELEASE_PRS"
+          echo "should-release=true" >> "$GITHUB_OUTPUT"
+          echo "bump-type=" >> "$GITHUB_OUTPUT"
+
   check-changesets:
     name: Check for changesets
+    needs: resolve-release-context
     runs-on: ubuntu-latest
     # Run when PR with 'release' label is merged to main, or when manually triggered
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request'
-       && github.event.pull_request.merged == true
-       && contains(github.event.pull_request.labels.*.name, 'release'))
+    if: needs.resolve-release-context.outputs.should-release == 'true'
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:
@@ -59,10 +122,10 @@ jobs:
 
   version-bump:
     name: Bump version and commit to main
-    needs: [check-changesets, notify-approval-needed]
+    needs: [resolve-release-context, check-changesets, notify-approval-needed]
     runs-on: ubuntu-latest
     # Use `always()` to ensure the job runs even if the notify-approval-needed job fails
-    if: always() && needs.check-changesets.outputs.has-changesets == 'true'
+    if: always() && needs.resolve-release-context.outputs.should-release == 'true' && needs.check-changesets.outputs.has-changesets == 'true'
     environment: 'NPM Release' # Requires approval from a maintainer
     permissions:
       contents: write


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow was triggered by `pull_request.closed`, so protected release environments could be requested from a `refs/pull/*/merge` ref instead of `refs/heads/main` after a PR merged. That can cause environment protection to reject the release even though the PR landed on `main`.

This ports the CI release fix from https://github.com/PostHog/posthog-js/pull/3461.

## Changes

- Trigger automatic releases from `push` to `main` instead of `pull_request.closed`.
- Keep `workflow_dispatch` for manual releases.
- Add a `resolve-release-context` job that skips automated version-bump commits, finds the PR associated with the pushed commit, and only continues when the merged PR currently has the `release` label.
- Limit push-triggered releases to changeset paths where the repo uses changesets/Sampo changesets, so unrelated pushes do not queue behind the release concurrency group.
- For bump-label release workflows, resolve the bump type from the associated PR labels and scope release concurrency to the protected release job because there is no changeset path to filter on.

## :green_heart: How did you test it?

- Parsed `.github/workflows/release.yml` as YAML.
- Ran `actionlint` on `.github/workflows/release.yml` (ignoring the pre-existing `actions/create-github-app-token@v3` `client-id`/`app-id` warning where that already exists in the workflow).
- Compared the workflow structure against the posthog-js reference PR: push trigger, release-context resolution, version-bump skip, release-label check, and gated release job.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
