### PR TITLE
fix: prefer projectToken for iOS config

### DIFF
--- a/.changeset/soft-badgers-dance.md
+++ b/.changeset/soft-badgers-dance.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native-session-replay': patch
+---
+
+Prefer projectToken over apiKey when starting iOS session replay.

--- a/ios/PosthogReactNativeSessionReplay.swift
+++ b/ios/PosthogReactNativeSessionReplay.swift
@@ -22,13 +22,16 @@ class PosthogReactNativeSessionReplay: NSObject {
             return
         }
 
-        let apiKey = sdkOptions["apiKey"] as? String ?? ""
+        let projectToken =
+            (sdkOptions["projectToken"] as? String)
+                ?? (sdkOptions["apiKey"] as? String)
+                ?? ""
         let host = sdkOptions["host"] as? String ?? PostHogConfig.defaultHost
         let debug = sdkOptions["debug"] as? Bool ?? false
 
         PostHogSessionManager.shared.setSessionId(sessionIdStr)
 
-        let config = PostHogConfig(apiKey: apiKey, host: host)
+        let config = PostHogConfig(projectToken: projectToken, host: host)
         config.sessionReplay = true
         config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.53.1 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.53.1'
+  # ~> Version 3.56.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '~> 3.56.0'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 


### PR DESCRIPTION
## Problem

The iOS PostHog SDK docs and config API now refer to the token as `projectToken` instead of `apiKey`. The session replay native module should accept the new option name while continuing to support existing callers that still send `apiKey`.

## Changes

- Read `sdkOptions["projectToken"]` first when starting iOS session replay.
- Fall back to `sdkOptions["apiKey"]` for backwards compatibility.
- Initialize `PostHogConfig` with the `projectToken:` initializer.
- Added a patch changeset for the release.

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
