### PR TITLE
chore: bump posthog-ios dependency to 3.57.1

### DIFF
--- a/.changeset/curly-ends-taste.md
+++ b/.changeset/curly-ends-taste.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native-session-replay': patch
+---
+
+chore: bump posthog-ios dependency to 3.57.1

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.56.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.56.0'
+  # ~> Version 3.57.1 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '~> 3.57.1'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 


### PR DESCRIPTION
## Problem

Bringing in session replay performance improvements from https://github.com/PostHog/posthog-ios/pull/578

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Checklist

- [ ] Tests for new code (if applicable)
- [ ] Accounted for the impact of any changes across iOS and Android platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
