### PR TITLE
No-op session replay init without API key

### DIFF
--- a/.changeset/noop-empty-api-key.md
+++ b/.changeset/noop-empty-api-key.md
@@ -1,0 +1,5 @@
+---
+"posthog-react-native-session-replay": patch
+---
+
+No-op native session replay startup when the project token or API key is missing or blank.

--- a/android/src/main/java/com/posthogreactnativesessionreplay/PosthogReactNativeSessionReplayModule.kt
+++ b/android/src/main/java/com/posthogreactnativesessionreplay/PosthogReactNativeSessionReplayModule.kt
@@ -33,11 +33,16 @@ class PosthogReactNativeSessionReplayModule(
     val initRunnable =
       Runnable {
         try {
+          val apiKey = getProjectTokenOrApiKey(sdkOptions)
+          if (apiKey.isEmpty()) {
+            logMessage("start", "Missing projectToken/apiKey. Session replay will not start.")
+            return@Runnable
+          }
+
           val uuid = UUID.fromString(sessionId)
           PostHogSessionManager.setSessionId(uuid)
 
           val context = this.reactApplicationContext
-          val apiKey = runCatching { sdkOptions.getString("apiKey") }.getOrNull() ?: ""
           val host = runCatching { sdkOptions.getString("host") }.getOrNull() ?: PostHogConfig.DEFAULT_HOST
           val debugValue = runCatching { sdkOptions.getBoolean("debug") }.getOrNull() ?: false
 
@@ -171,6 +176,15 @@ class PosthogReactNativeSessionReplayModule(
     }
   }
 
+  private fun getProjectTokenOrApiKey(sdkOptions: ReadableMap): String {
+    val projectToken = runCatching { sdkOptions.getString("projectToken")?.trim() }.getOrNull()
+    if (!projectToken.isNullOrEmpty()) {
+      return projectToken
+    }
+
+    return runCatching { sdkOptions.getString("apiKey")?.trim() }.getOrNull().orEmpty()
+  }
+
   private fun setIdentify(
     cachePreferences: PostHogPreferences?,
     distinctId: String,
@@ -216,6 +230,13 @@ class PosthogReactNativeSessionReplayModule(
     error: Throwable,
   ) {
     Log.println(Log.ERROR, POSTHOG_TAG, "Method $method, error: $error")
+  }
+
+  private fun logMessage(
+    method: String,
+    message: String,
+  ) {
+    Log.println(Log.WARN, POSTHOG_TAG, "Method $method, $message")
   }
 
   companion object {

--- a/ios/PosthogReactNativeSessionReplay.swift
+++ b/ios/PosthogReactNativeSessionReplay.swift
@@ -23,9 +23,15 @@ class PosthogReactNativeSessionReplay: NSObject {
         }
 
         let projectToken =
-            (sdkOptions["projectToken"] as? String)
-                ?? (sdkOptions["apiKey"] as? String)
+            normalizedString(sdkOptions["projectToken"])
+                ?? normalizedString(sdkOptions["apiKey"])
                 ?? ""
+        guard !projectToken.isEmpty else {
+            hedgeLog("Missing projectToken/apiKey. Session replay will not start.")
+            resolve(nil)
+            return
+        }
+
         let host = sdkOptions["host"] as? String ?? PostHogConfig.defaultHost
         let debug = sdkOptions["debug"] as? Bool ?? false
 
@@ -151,6 +157,14 @@ class PosthogReactNativeSessionReplay: NSObject {
         setIdentify(storageManager, distinctId: distinctIdStr, anonymousId: anonymousIdStr)
 
         resolve(nil)
+    }
+
+    private func normalizedString(_ value: Any?) -> String? {
+        guard let stringValue = value as? String else {
+            return nil
+        }
+        let trimmedValue = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
     }
 
     private func setIdentify(


### PR DESCRIPTION
## Problem

Session replay native startup can attempt to initialize PostHog with a missing, empty, or whitespace-only project token/API key. This can throw or call native setup with an invalid key.

## Changes

- Trim and prefer `projectToken`, falling back to trimmed `apiKey`, on iOS and Android.
- Resolve/log without native PostHog setup when both values are missing or blank.
- Add a patch changeset for release.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec jest --passWithNoTests` (no tests found)
- [ ] `cd example/android && ./gradlew projects --no-daemon` (fails in React Native Gradle plugin dependency: warnings treated as errors)
- [ ] `cd android && ./gradlew compileDebugKotlin --no-daemon` (standalone android project cannot resolve Android library plugin)

## Checklist

- [x] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [x] Added a changeset file
- [x] Added the `release` label to the PR
