### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,5 @@
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.changeset/**'
+      - '.changeset/*.md'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -119,7 +119,7 @@ jobs:
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release $NEW_VERSION [version bump]"
+            git commit -m "chore: release $NEW_VERSION [version bump] [skip ci]"
             git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.changeset/**'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -18,12 +19,6 @@ jobs:
   check-changesets:
     name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to main, or when manually triggered
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request'
-       && github.event.pull_request.merged == true
-       && contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,89 +6,40 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ### 1. Add a Changeset
 
-When making changes that should be released, add a changeset:
+When making a change that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This will prompt you to:
-- Select the type of version bump (patch, minor, major)
-- Write a summary of the changes
+This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
 
-The changeset file will be created in the `.changeset/` directory.
+### 2. Merge the Pull Request
 
-### 2. Create a Pull Request
+After review, merge the PR to `main`. No GitHub release label is required.
 
-Create a PR with your changes and the changeset file(s).
+A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
 
-### 3. Add the `release` Label
-
-When the PR is ready to be released, add the `release` label to it.
-
-### 4. Merge the PR
-
-When the PR is merged to `main`, the release workflow will automatically:
-
-1. Check for changesets
-2. Notify the client libraries team in Slack for approval
-3. Wait for approval from a maintainer (via GitHub environment protection)
-4. Once approved:
-   - Apply changesets and bump the version
-   - Update the CHANGELOG.md
-   - Commit the version bump to `main`
-   - Publish the package to NPM
-   - Create a git tag and GitHub release
+1. Checks for pending changesets
+2. Notifies the client libraries team in Slack for approval
+3. Waits for approval from a maintainer via the GitHub `Release` environment
+4. The workflow applies Changesets, publishes the npm package, tags the release, and creates a GitHub Release.
+5. Notifies Slack when the release completes or fails
 
 ### Manual Trigger
 
-You can also manually trigger the release workflow from the [Actions tab](https://github.com/PostHog/posthog-react-native-session-replay/actions/workflows/release.yml) by clicking "Run workflow".
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
 
 ## Version Bumping
 
-Changesets handles version bumping automatically based on the changesets you create:
+Changesets determines the next version from the committed changeset files:
 
-- **patch**: Bug fixes, documentation updates, internal changes (e.g., `1.2.3` → `1.2.4`)
-- **minor**: New features, non-breaking changes (e.g., `1.2.3` → `1.3.0`)
-- **major**: Breaking changes (e.g., `1.2.3` → `2.0.0`)
-
-## Pre-release Versions
-
-For pre-release versions (alpha, beta, RC), you can manually enter pre-release mode:
-
-```bash
-pnpm changeset pre enter alpha  # or beta, rc
-pnpm changeset version
-```
-
-To exit pre-release mode:
-
-```bash
-pnpm changeset pre exit
-```
-
-## NPM Package
-
-The package is published as [`posthog-react-native-session-replay`](https://www.npmjs.com/package/posthog-react-native-session-replay) on NPM.
+- **patch**: bug fixes, documentation updates, and internal changes
+- **minor**: backwards-compatible features
+- **major**: breaking changes
 
 ## Troubleshooting
 
 ### No changesets found
 
-If the release workflow fails with "No changesets found", ensure your PR includes at least one changeset file in the `.changeset/` directory.
-
-### Release not triggered
-
-Make sure the PR has the `release` label applied before merging.
-
-### Manual NPM publish (emergency only)
-
-In case of automation failure, you can manually publish:
-
-```bash
-pnpm install
-pnpm prepare  # builds the package
-npm publish
-```
-
-You'll need to be authenticated with NPM and have publish access to the package.
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,40 +6,85 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ### 1. Add a Changeset
 
-When making a change that should be released, add a changeset:
+When making changes that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+This will prompt you to:
+- Select the type of version bump (patch, minor, major)
+- Write a summary of the changes
 
-### 2. Merge the Pull Request
+The changeset file will be created in the `.changeset/` directory.
 
-After review, merge the PR to `main`. No GitHub release label is required.
+### 2. Create a Pull Request
 
-A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+Create a PR with your changes and the changeset file(s).
 
-1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, publishes the npm package, tags the release, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+### 3. Merge the PR
+
+No release label is required. When the PR is merged to `main`, the release workflow will automatically:
+
+1. Check for changesets
+2. Notify the client libraries team in Slack for approval
+3. Wait for approval from a maintainer (via GitHub environment protection)
+4. Once approved:
+   - Apply changesets and bump the version
+   - Update the CHANGELOG.md
+   - Commit the version bump to `main`
+   - Publish the package to NPM
+   - Create a git tag and GitHub release
 
 ### Manual Trigger
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+You can also manually trigger the release workflow from the [Actions tab](https://github.com/PostHog/posthog-react-native-session-replay/actions/workflows/release.yml) by clicking "Run workflow".
 
 ## Version Bumping
 
-Changesets determines the next version from the committed changeset files:
+Changesets handles version bumping automatically based on the changesets you create:
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
+- **patch**: Bug fixes, documentation updates, internal changes (e.g., `1.2.3` → `1.2.4`)
+- **minor**: New features, non-breaking changes (e.g., `1.2.3` → `1.3.0`)
+- **major**: Breaking changes (e.g., `1.2.3` → `2.0.0`)
+
+## Pre-release Versions
+
+For pre-release versions (alpha, beta, RC), you can manually enter pre-release mode:
+
+```bash
+pnpm changeset pre enter alpha  # or beta, rc
+pnpm changeset version
+```
+
+To exit pre-release mode:
+
+```bash
+pnpm changeset pre exit
+```
+
+## NPM Package
+
+The package is published as [`posthog-react-native-session-replay`](https://www.npmjs.com/package/posthog-react-native-session-replay) on NPM.
 
 ## Troubleshooting
 
 ### No changesets found
 
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+If the release workflow fails with "No changesets found", ensure your PR includes at least one changeset file in the `.changeset/` directory.
+
+### Release not triggered
+
+Make sure the PR includes a changeset file and was merged to `main`, or trigger the workflow manually from the Actions tab.
+
+### Manual NPM publish (emergency only)
+
+In case of automation failure, you can manually publish:
+
+```bash
+pnpm install
+pnpm prepare  # builds the package
+npm publish
+```
+
+You'll need to be authenticated with NPM and have publish access to the package.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ This prompts you to select the version bump (`patch`, `minor`, or `major`) and w
 
 After review, merge the PR to `main`. No GitHub release label is required.
 
-A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
+A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending changesets
 2. Notifies the client libraries team in Slack for approval


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.changeset/**`, while keeping manual `workflow_dispatch`
- Removed release-label and bump-label checks from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request`, PR labels, or bump labels
- Verified PR templates no longer ask for release labels

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed for this release-process-only change)