### PR TITLE
chore: sign release workflow commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      committed: ${{ steps.commit-version-bump.outputs.committed }}
+      committed: ${{ steps.check-changes.outputs.committed }}
       new-version: ${{ steps.apply-changesets.outputs.new-version }}
     steps:
       - name: Notify Slack - Approved
@@ -108,22 +108,26 @@ jobs:
       - name: Update lockfile
         run: pnpm install --no-frozen-lockfile
 
-      - name: Commit version bump and lockfile
-        id: commit-version-bump
-        env:
-          GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
-          NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
+      - name: Check for version bump changes
+        id: check-changes
         run: |
-          git add -A
-          if git diff --staged --quiet; then
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release $NEW_VERSION [version bump] [skip ci]"
-            git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Commit version bump and lockfile
+        id: commit-version-bump
+        if: steps.check-changes.outputs.committed == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "chore: release ${{ steps.apply-changesets.outputs.new-version }} [version bump] [skip ci]"
+          repo: ${{ github.repository }}
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
       - name: Notify Slack - Failed
         continue-on-error: true
         if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      committed: ${{ steps.check-changes.outputs.committed }}
+      committed: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
       new-version: ${{ steps.apply-changesets.outputs.new-version }}
     steps:
       - name: Notify Slack - Approved


### PR DESCRIPTION
## Problem

The release workflow commits version bump changes during automated releases. Raw `git commit` / `git push` can fail in repositories that require verified commit signatures.

## Changes

- Replace raw release workflow commits with `planetscale/ghcommit-action`.
- Keep release follow-up steps gated on whether release files changed.

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
