### PR TITLE
chore: bridge the experimental iOS background screenshot capture option

### DIFF
--- a/.changeset/sunny-bugs-arrive.md
+++ b/.changeset/sunny-bugs-arrive.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native-session-replay': patch
+---
+
+chore: bridge the experimental iOS background screenshot capture option and bump posthog-ios dependency to 3.58.1

--- a/ios/PosthogReactNativeSessionReplay.swift
+++ b/ios/PosthogReactNativeSessionReplay.swift
@@ -68,6 +68,9 @@ class PosthogReactNativeSessionReplay: NSObject {
 
         config.sessionReplayConfig.sampleRate = sdkReplayConfig["sampleRate"] as? NSNumber
 
+        let screenshotModeBackgroundCapture = sdkReplayConfig["screenshotModeBackgroundCapture"] as? Bool ?? false
+        config.sessionReplayConfig.screenshotModeBackgroundCapture = screenshotModeBackgroundCapture
+
         let endpoint = decideReplayConfig["endpoint"] as? String ?? ""
         if !endpoint.isEmpty {
             config.snapshotEndpoint = endpoint

--- a/posthog-react-native-session-replay.podspec
+++ b/posthog-react-native-session-replay.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{swift,h,hpp,m,mm,c,cpp}"
 
-  # ~> Version 3.57.6 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.57.6'
+  # ~> Version 3.58.1 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '~> 3.58.1'
   s.ios.deployment_target = '13.0'
   s.swift_versions = "5.3"
 


### PR DESCRIPTION
## Problem

PostHog iOS `3.58.1` adds an experimental Session Replay screenshot mode option, `screenshotModeBackgroundCapture` which allows screenshot rendering to be scheduled on a background queue to reduce main-thread pressure.

The React Native Session Replay plugin needs to depend on that iOS SDK version and pass the option through when provided by `posthog-react-native`.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Checklist

- [ ] Tests for new code (if applicable)
- [ ] Accounted for the impact of any changes across iOS and Android platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
