### PR TITLE
ci: bump notify-approval-needed reusable workflow SHA to fix Slack release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     name: Notify Slack - Approval Needed
     needs: check-changesets
     if: needs.check-changesets.outputs.has-changesets == 'true'
-    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}


### PR DESCRIPTION
## Problem

The `Notify Slack - Approval Needed` job in our `Release` workflow has been failing silently on every changeset-based release. Symptom: every release sits at the `Bump version and commit to main` environment-protection gate with no Slack notification ever fired, so the client-libraries team has no idea a release is pending approval.

First confirmed instance: yesterday's [Release run 26473920035](https://github.com/PostHog/posthog-react-native-session-replay/actions/runs/26473920035) for the `1.6.0` release of #81. We had to approve it manually because the auto-notification didn't go out.

## Root cause

`release.yml` line 47 currently calls the org-level reusable workflow at a stale SHA:

```yaml
uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@d2e7c952fef6a22b2210bcffc70bec71abeeba03
```

At that SHA, the reusable workflow contains two **unpinned** action refs:
- [Line 29 — `actions/checkout@v6`](https://github.com/PostHog/.github/blob/d2e7c952fef6a22b2210bcffc70bec71abeeba03/.github/workflows/notify-approval-needed.yml#L29) (tag, not SHA)
- [Line 128 — `PostHog/posthog-github-action@v1.1.1`](https://github.com/PostHog/.github/blob/d2e7c952fef6a22b2210bcffc70bec71abeeba03/.github/workflows/notify-approval-needed.yml#L128) (tag, not SHA)

The org-level `ensure-pinned-actions` audit (introduced into our repo's main ruleset by #80) rejects these, the Slack-notify job fails its checkout step, and no message gets posted.

`PostHog/.github` has since fixed these — [main today](https://github.com/PostHog/.github/blob/main/.github/workflows/notify-approval-needed.yml#L29) has both refs properly SHA-pinned. We just need to bump the pin.

## Change

```diff
- uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+ uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
```

The new SHA is current `PostHog/.github@main`. Diff between the two SHAs is just the SHA-pinning of those two action refs; no behavioral changes to the workflow.

## Verification

Compare the same file at the two SHAs:
- Old: https://github.com/PostHog/.github/blob/d2e7c952fef6a22b2210bcffc70bec71abeeba03/.github/workflows/notify-approval-needed.yml#L29
- New: https://github.com/PostHog/.github/blob/5fc4680761e8ac29a61b212756230eba0e276d8c/.github/workflows/notify-approval-needed.yml#L29

Will be verified end-to-end on the next changeset release after this PR merges — the Slack notification should fire.

## Other PostHog repos affected by the same stale pin

A quick `gh search code` found four other repos pinning the same stale SHA:
- `PostHog/posthog-flutter` — `.github/workflows/publish.yml`
- `PostHog/posthog-dotnet` — `.github/workflows/release.yml`
- `PostHog/posthog-rs` — `.github/workflows/release.yml`
- `PostHog/mcp-analytics` — `.github/workflows/release.yml`

They almost certainly have the same broken Slack-notify behavior. Worth a follow-up sweep.

## Checklist

- [x] Tests for new code (if applicable) — N/A (workflow YAML change)
- [x] Accounted for the impact of any changes across iOS and Android platforms — N/A (release workflow, not platform code)
- [x] Accounted for backwards compatibility of any changes (no breaking changes!) — yes, no behavioral change

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file — N/A, no library changes
