### PR TITLE
chore: gate npm publishing behind release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       posthog_project_api_key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
 
   version-bump:
-    name: Bump version and commit to main
+    name: Bump version and publish
     needs: [check-changesets, notify-approval-needed]
     runs-on: ubuntu-latest
     # Use `always()` to ensure the job runs even if the notify-approval-needed job fails
@@ -61,9 +61,11 @@ jobs:
     environment: 'NPM Release' # Requires approval from a maintainer
     permissions:
       contents: write
+      id-token: write
     outputs:
       committed: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
       new-version: ${{ steps.apply-changesets.outputs.new-version }}
+      published: ${{ steps.publish-status.outputs.published == 'true' }}
     steps:
       - name: Notify Slack - Approved
         continue-on-error: true
@@ -128,6 +130,85 @@ jobs:
           branch: main
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
+
+      - name: Sync checkout to release commit
+        if: steps.commit-version-bump.outputs.commit-hash != ''
+        env:
+          COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
+        run: |
+          git fetch origin main
+          git reset --hard "$COMMIT_HASH"
+
+      - name: Check package version
+        id: check-package-version
+        if: steps.commit-version-bump.outputs.commit-hash != ''
+        uses: PostHog/check-package-version@f540540cb12d45ec3c58d42dbf1d60070ed2d268 # v2.1.1
+
+      - name: Build package
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        run: pnpm prepare
+
+      - name: Tag repository
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        env:
+          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+        run: |
+          git tag -a "$COMMITTED_VERSION" -m "$COMMITTED_VERSION"
+
+      - name: Publish to NPM
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Mark package as published
+        id: publish-status
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag to GitHub
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        env:
+          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+        run: |
+          git push origin "$COMMITTED_VERSION"
+
+      - name: Create GitHub release
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+        run: |
+          # Read from the first until the second header in the changelog file
+          LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## Next$/{next} /^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/releases \
+            -f tag_name="$COMMITTED_VERSION" \
+            -f target_commitish='main' \
+            -f name="$COMMITTED_VERSION" \
+            -f body="$LAST_CHANGELOG_ENTRY" \
+            -F draft=false \
+            -F prerelease=false \
+            -F generate_release_notes=false
+
+      # Notify in case of failure
+      - name: Send failure event to PostHog
+        if: ${{ failure() }}
+        uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+        with:
+          posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+          event: 'posthog-react-native-session-replay-release-workflow-failure'
+          properties: >-
+            {
+              "commitSha": "${{ github.sha }}",
+              "jobStatus": "${{ job.status }}",
+              "ref": "${{ github.ref }}",
+              "packageVersion": "${{ steps.check-package-version.outputs.committed-version || steps.apply-changesets.outputs.new-version }}"
+            }
+
       - name: Notify Slack - Failed
         continue-on-error: true
         if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
@@ -136,7 +217,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: '❌ Failed to bump version for `posthog-react-native-session-replay@${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+          message: '❌ Failed to release `posthog-react-native-session-replay@${{ steps.check-package-version.outputs.committed-version || steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
           emoji_reaction: 'x'
 
   notify-rejected:
@@ -179,109 +260,11 @@ jobs:
           message: '${{ steps.check-rejection.outputs.message }}'
           emoji_reaction: 'no_entry_sign'
 
-  publish:
-    name: Publish to NPM
-    needs: [version-bump, notify-approval-needed]
-    runs-on: ubuntu-latest
-    if: always() && needs.version-bump.outputs.committed == 'true'
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Setup environment
-        uses: ./.github/actions/setup
-
-      - name: Check package version
-        id: check-package-version
-        uses: PostHog/check-package-version@f540540cb12d45ec3c58d42dbf1d60070ed2d268 # v2.1.1
-
-      - name: Build package
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        run: pnpm prepare
-
-      - name: Tag repository
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        env:
-          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-        run: |
-          git tag -a "$COMMITTED_VERSION" -m "$COMMITTED_VERSION"
-
-      - name: Publish to NPM
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
-
-      - name: Push tag to GitHub
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        env:
-          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-        run: |
-          git push origin "$COMMITTED_VERSION"
-
-      - name: Create GitHub release
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-        run: |
-          # Read from the first until the second header in the changelog file
-          LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## Next$/{next} /^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/releases \
-            -f tag_name="$COMMITTED_VERSION" \
-            -f target_commitish='main' \
-            -f name="$COMMITTED_VERSION" \
-            -f body="$LAST_CHANGELOG_ENTRY" \
-            -F draft=false \
-            -F prerelease=false \
-            -F generate_release_notes=false
-
-      # Notify in case of failure
-      - name: Send failure event to PostHog
-        if: ${{ failure() }}
-        uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
-        with:
-          posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-          event: 'posthog-react-native-session-replay-release-workflow-failure'
-          properties: >-
-            {
-              "commitSha": "${{ github.sha }}",
-              "jobStatus": "${{ job.status }}",
-              "ref": "${{ github.ref }}",
-              "packageVersion": "${{ steps.check-package-version.outputs.committed-version }}"
-            }
-
-      - name: Notify Slack - Failed
-        continue-on-error: true
-        if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
-        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
-        with:
-          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
-          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
-          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: '❌ Failed to release `posthog-react-native-session-replay@${{ steps.check-package-version.outputs.committed-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
-          emoji_reaction: 'x'
-
   notify-released:
     name: Notify Slack - Released
-    needs: [notify-approval-needed, publish]
+    needs: [notify-approval-needed, version-bump]
     runs-on: ubuntu-latest
-    if: always() && needs.publish.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
+    if: always() && needs.version-bump.result == 'success' && needs.version-bump.outputs.published == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Notify Slack - Released
         continue-on-error: true


### PR DESCRIPTION
## Problem

Release workflow approval should protect the actual package publishing, release tag creation, and GitHub release creation steps. Relying on a downstream publish job with only `needs:` is not a security boundary because a workflow edit could remove that dependency.

## Changes

- Move package publishing, release tag creation, and GitHub release creation into the environment-gated release job.
- Update release notifications to depend on the gated release job outputs.

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
