### PR TITLE
docs: add plugin move notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # posthog-react-native-session-replay
 
+> [!IMPORTANT]
+> This plugin has moved to the PostHog JavaScript monorepo and has been renamed from `posthog-react-native-session-replay` to `@posthog/react-native-plugin`.
+>
+> New repository: https://github.com/PostHog/posthog-js/tree/main/packages/react-native-plugin
+
 Session Replay for React Native (Android and iOS)
 
 ## Installation


### PR DESCRIPTION
## Problem

The README still needs to direct users to the new home and package name for this plugin while preserving the existing repository documentation.

## Changes

Adds an important note at the top of the README explaining that the plugin moved to the PostHog JavaScript monorepo and was renamed from `posthog-react-native-session-replay` to `@posthog/react-native-plugin`.

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Accounted for the impact of any changes across iOS and Android platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
